### PR TITLE
Typo fix

### DIFF
--- a/scenes.py
+++ b/scenes.py
@@ -166,8 +166,8 @@ scenes = {
     # COMBAT
     "TutorialCombat": {
         "text": (
-            "You enter a small room where a training dummy stands in the center./n"
-            "A sign on the wall reads: 'Practice your combat skills here.\n"
+            "You enter a small room where a training dummy stands in the center.\n"
+            "A sign on the wall reads: 'Practice your combat skills here'.\n"
             "You can see a sword lying next to the dummy, ready for you to pick up.\n\n"
             "What will you do?\n"
         ),


### PR DESCRIPTION
This pull request includes a minor fix to the `scenes.py` file. The change corrects formatting issues in the `TutorialCombat` scene's text by replacing an incorrect `/n` with the proper newline character `\n` and ensuring consistent punctuation.