### PR TITLE
Add new items and update storeroom scene

### DIFF
--- a/items.py
+++ b/items.py
@@ -18,6 +18,7 @@
 # }
 
 items = {
+    # WEAPONS
     "rusty_sword": {
         "description": "An old, weathered sword with rust spots along the blade. +5 damage.",
         "metadata": { 
@@ -31,12 +32,57 @@ items = {
             },
         }
     },
+    "dagger": {
+        "description": "A sharp dagger with a leather-wrapped handle. +3 damage.",
+        "metadata": {
+            "type": "weapon",
+            "value": 15,
+            "effects": ["damage"],
+            "base_stats": {
+                "damage": 3,
+                "defense": 0,
+                "healing": 0
+            },
+        }
+    },
+    
+    # TOOLS
     "rusty_lockpick": {
         "description": "A rusty lockpick, barely functional but still usable.",
         "metadata": {
             "type": "tool",
             "value": 5,
             "effects": ["unlock"],
+            "base_stats": {
+                "damage": 0,
+                "defense": 0,
+                "healing": 0
+            },
+        }
+    },
+    
+    # POTIONS
+    "sleep_draught": {
+        "description": "A potion that induces sleep, useful for stealth.",
+        "metadata": {
+            "type": "potion",
+            "value": 20,
+            "effects": ["sleep"],
+            "base_stats": {
+                "damage": 0,
+                "defense": 0,
+                "healing": 0
+            },
+        }
+    },
+    
+    # NOTES
+    "temple_note": {
+        "description": "A note found in the storeroom of the prison. 'The elder is awaiting your reply'.",
+        "metadata": {
+            "type": "note",
+            "value": 0,
+            "effects": ["quest"],
             "base_stats": {
                 "damage": 0,
                 "defense": 0,

--- a/scenes.py
+++ b/scenes.py
@@ -235,7 +235,7 @@ scenes = {
         },
     },
 
-# Tutoral over
+# Tutorial over
     "OutsideForest": {
         "text": (
             "You emerge from the sewer into the forest outside the prison. The moon hangs low and mist clings to the trees.\n"

--- a/scenes.py
+++ b/scenes.py
@@ -111,13 +111,11 @@ scenes = {
         "text": (
             "Inside the dusty storeroom, you find old tools and supplies.\n"
             "Among the clutter is a small dagger wrapped in cloth and a vial labeled 'sleep draught'.\n"
-            "You also spot a torn note: 'Temple lies beyond the roots of fire and ash.'\n\n"
+            "You also spot a torn note: 'The elder is awaiting your reply.'\n\n"
             "What do you take?\n"
         ),
         "choices": {
-            "take dagger and vial": "SewerEntrance",
-            "just take the note": "SewerEntrance",
-            "leave everything": "SewerEntrance",
+            "go back and enter the narrow passage": "SewerEntrance",
         },
         "metadata": {
             "items": ["dagger", "sleep_draught", "temple_note"],
@@ -151,18 +149,7 @@ scenes = {
             "clue": True,
         },
     },
-    "OutsideForest": {
-        "text": (
-            "You emerge from the sewer into the forest outside the prison. The moon hangs low and mist clings to the trees.\n"
-            "Freedom — for now. But the shadows of the Elder's men stretch far.\n"
-            "Ahead, you see a faint flickering — a campfire. Could be danger. Could be a lead.\n\n"
-            "What will you do?\n"
-        ),
-        "choices": {
-            "approach campfire stealthily": "CampfireScene",
-            "avoid camp and head into the woods": "ForestWander",
-        },
-    },
+
     # COMBAT
     "TutorialCombat": {
         "text": (
@@ -245,6 +232,20 @@ scenes = {
         "choices": {
             "crawl through passage": "SewerEntrance",
             "go back and fight the guard": "GuardCombat",
+        },
+    },
+
+# Tutoral over
+    "OutsideForest": {
+        "text": (
+            "You emerge from the sewer into the forest outside the prison. The moon hangs low and mist clings to the trees.\n"
+            "Freedom — for now. But the shadows of the Elder's men stretch far.\n"
+            "Ahead, you see a faint flickering — a campfire. Could be danger. Could be a lead.\n\n"
+            "What will you do?\n"
+        ),
+        "choices": {
+            "approach campfire stealthily": "CampfireScene",
+            "avoid camp and head into the woods": "ForestWander",
         },
     },
 }


### PR DESCRIPTION
Introduced new items: dagger, sleep draught, and temple note in items.py. Updated the storeroom scene in scenes.py to reference these items and revised the note's text. Adjusted scene choices for clarity and fixed a misplaced scene block.